### PR TITLE
Add semaphore option to sqs consumer

### DIFF
--- a/dist/consumer.js
+++ b/dist/consumer.js
@@ -270,6 +270,8 @@ class Consumer extends events_1.EventEmitter {
                     this.emit('semaphore_release');
                     this.emit('error', err);
                 });
+            }).catch((err) => {
+                this.emit('error', err);
             });
         }
         else {

--- a/dist/consumer.js
+++ b/dist/consumer.js
@@ -61,6 +61,7 @@ class Consumer extends events_1.EventEmitter {
         this.queueUrl = options.queueUrl;
         this.handleMessage = options.handleMessage;
         this.handleMessageBatch = options.handleMessageBatch;
+        this.semaphore = options.semaphore;
         this.handleMessageTimeout = options.handleMessageTimeout;
         this.attributeNames = options.attributeNames || [];
         this.messageAttributeNames = options.messageAttributeNames || [];
@@ -244,7 +245,7 @@ class Consumer extends events_1.EventEmitter {
             VisibilityTimeout: this.visibilityTimeout
         };
         let currentPollingTimeout = this.pollingWaitTimeMs;
-        this.receiveMessage(receiveParams)
+        const receiveAndHandleFlow = () => (this.receiveMessage(receiveParams)
             .then(this.handleSqsResponse)
             .catch((err) => {
             this.emit('error', err);
@@ -253,11 +254,32 @@ class Consumer extends events_1.EventEmitter {
                 currentPollingTimeout = this.authenticationErrorTimeout;
             }
             return;
-        }).then(() => {
-            setTimeout(this.poll, currentPollingTimeout);
-        }).catch((err) => {
-            this.emit('error', err);
-        });
+        }));
+        if (this.semaphore) {
+            this.semaphore.acquire()
+                .then(([, release]) => {
+                this.emit('semaphore_acquire');
+                setTimeout(this.poll, 0);
+                receiveAndHandleFlow()
+                    .then(() => {
+                    release();
+                    this.emit('semaphore_release');
+                })
+                    .catch((err) => {
+                    release();
+                    this.emit('semaphore_release');
+                    this.emit('error', err);
+                });
+            });
+        }
+        else {
+            receiveAndHandleFlow()
+                .then(() => {
+                setTimeout(this.poll, currentPollingTimeout);
+            }).catch((err) => {
+                this.emit('error', err);
+            });
+        }
     }
     async processMessageBatch(messages) {
         messages.forEach((message) => {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -363,8 +363,9 @@ export class Consumer extends EventEmitter {
               this.emit('semaphore_release');
               this.emit('error', err);
             });
-        }
-        );
+        }).catch((err)=> {
+          this.emit('error', err);
+        });
     } else {
       receiveAndHandleFlow()
         .then(() => {

--- a/src/consumer.ts
+++ b/src/consumer.ts
@@ -73,6 +73,14 @@ function hasMessages(response: ReceieveMessageResponse): boolean {
   return response.Messages && response.Messages.length > 0;
 }
 
+interface Releaser {
+  (): void;
+}
+
+export interface Semaphore {
+  acquire: () => Promise<[number, Releaser]>;
+}
+
 export interface ConsumerOptions {
   queueUrl?: string;
   attributeNames?: string[];
@@ -90,12 +98,15 @@ export interface ConsumerOptions {
   handleMessageTimeout?: number;
   handleMessage?(message: SQSMessage, deleteMessage?: () => Promise<void>): Promise<void>;
   handleMessageBatch?(messages: SQSMessage[], deleteMessages?: () => Promise<void>): Promise<void>;
+  semaphore?: Semaphore;
   manualDelete?: boolean;
 }
 
 interface Events {
   'response_processed': [];
   'empty': [];
+  'semaphore_acquire': [];
+  'semaphore_release': [];
   'message_received': [SQSMessage];
   'message_processed': [SQSMessage];
   'error': [Error, void | SQSMessage | SQSMessage[]];
@@ -108,6 +119,7 @@ export class Consumer extends EventEmitter {
   private queueUrl: string;
   private handleMessage: (message: SQSMessage, deleteMessage?: () => Promise<void>) => Promise<void>;
   private handleMessageBatch: (message: SQSMessage[], deleteMessages?: () => Promise<void>) => Promise<void>;
+  private semaphore: Semaphore;
   private handleMessageTimeout: number;
   private attributeNames: string[];
   private messageAttributeNames: string[];
@@ -128,6 +140,7 @@ export class Consumer extends EventEmitter {
     this.queueUrl = options.queueUrl;
     this.handleMessage = options.handleMessage;
     this.handleMessageBatch = options.handleMessageBatch;
+    this.semaphore = options.semaphore;
     this.handleMessageTimeout = options.handleMessageTimeout;
     this.attributeNames = options.attributeNames || [];
     this.messageAttributeNames = options.messageAttributeNames || [];
@@ -322,20 +335,45 @@ export class Consumer extends EventEmitter {
     };
 
     let currentPollingTimeout = this.pollingWaitTimeMs;
-    this.receiveMessage(receiveParams)
-      .then(this.handleSqsResponse)
-      .catch((err) => {
-        this.emit('error', err);
-        if (isConnectionError(err)) {
-          debug('There was an authentication error. Pausing before retrying.');
-          currentPollingTimeout = this.authenticationErrorTimeout;
+    const receiveAndHandleFlow = () => (
+      this.receiveMessage(receiveParams)
+        .then(this.handleSqsResponse)
+        .catch((err) => {
+          this.emit('error', err);
+          if (isConnectionError(err)) {
+            debug('There was an authentication error. Pausing before retrying.');
+            currentPollingTimeout = this.authenticationErrorTimeout;
+          }
+          return;
+        })
+    );
+
+    if (this.semaphore) {
+      this.semaphore.acquire()
+        .then(([, release]) => {
+          this.emit('semaphore_acquire');
+          setTimeout(this.poll, 0);
+          receiveAndHandleFlow()
+            .then(() => {
+              release();
+              this.emit('semaphore_release');
+            })
+            .catch((err) => {
+              release();
+              this.emit('semaphore_release');
+              this.emit('error', err);
+            });
         }
-        return;
-      }).then(() => {
-        setTimeout(this.poll, currentPollingTimeout);
-      }).catch((err) => {
-        this.emit('error', err);
-      });
+        );
+    } else {
+      receiveAndHandleFlow()
+        .then(() => {
+          setTimeout(this.poll, currentPollingTimeout);
+        }).catch((err) => {
+          this.emit('error', err);
+        });
+    }
+
   }
 
   private async processMessageBatch(messages: SQSMessage[]): Promise<void> {

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -709,6 +709,26 @@ describe('Consumer', () => {
       sandbox.assert.callCount(semaphoreRelease, 1);
     });
 
+    it('emits error if semaphore.acquire fails', async () => {
+      semaphore.acquire = sinon.stub().rejects('semaphore acquire error');
+      consumer = new Consumer({
+        queueUrl: 'some-queue-url',
+        messageAttributeNames: ['attribute-1', 'attribute-2'],
+        region: 'some-region',
+        handleMessage,
+        semaphore,
+        sqs
+      });
+
+      consumer.start();
+      await pEvent(consumer, 'error');
+      consumer.stop();
+
+      sandbox.assert.callCount(semaphore.acquire, 1);
+      sandbox.assert.callCount(semaphoreRelease, 0);
+      sandbox.assert.callCount(handleMessage, 0);
+    });
+
     it('extends visibility timeout for long running handler functions', async () => {
       consumer = new Consumer({
         queueUrl: 'some-queue-url',

--- a/test/consumer.ts
+++ b/test/consumer.ts
@@ -9,6 +9,52 @@ const sandbox = sinon.createSandbox();
 const AUTHENTICATION_ERROR_TIMEOUT = 20;
 const POLLING_TIMEOUT = 100;
 
+interface TestReleaser {
+  (): void;
+}
+
+interface TestResolveWithReleaser {
+  (value: [number, TestReleaser]): void;
+}
+
+const TestSemaphore = class {
+  public capacity: number;
+  public count: number;
+  public acquireCount: number;
+  public releaseCount: number;
+  public notReadyCount: number;
+  constructor(capacity: number) {
+    this.capacity = capacity;
+    this.count = 0;
+    this.acquireCount = 0;
+    this.releaseCount = 0;
+    this.notReadyCount = 0;
+  }
+
+  private resolveReleaser(sem: any, resolve: TestResolveWithReleaser): void {
+    if (sem.count >= sem.capacity) {
+      sem.notReadyCount += 1;
+      setTimeout(sem.resolveReleaser, 5, sem, resolve);
+      return;
+    }
+
+    sem.count += 1;
+    function release() {
+      sem.releaseCount += 1;
+      sem.count -= 1;
+    }
+
+    resolve([0, release]);
+  }
+
+  public acquire(): Promise<[number, TestReleaser]> {
+    this.acquireCount += 1;
+    return new Promise((resolve) => {
+      this.resolveReleaser(this, resolve);
+    });
+  }
+};
+
 function stubResolve(value?: any): any {
   return sandbox
     .stub()
@@ -727,6 +773,42 @@ describe('Consumer', () => {
       sandbox.assert.callCount(semaphore.acquire, 1);
       sandbox.assert.callCount(semaphoreRelease, 0);
       sandbox.assert.callCount(handleMessage, 0);
+    });
+
+    it('respects semaphore capacity', async () => {
+      const expectedAcquireCount = 16;
+      const expectedHandleMessageCount = 15;
+      const expectedReleaseCount = 10;
+      const expectesNotReadCount = 118;
+      const semaphoreCapacity = 5;
+      let handleMessageCount = 0;
+      const testSem = new TestSemaphore(semaphoreCapacity);
+
+      consumer = new Consumer({
+        queueUrl: 'some-queue-url',
+        messageAttributeNames: ['attribute-1', 'attribute-2'],
+        region: 'some-region',
+        handleMessage: () => new Promise((resolve) => {
+          handleMessageCount += 1;
+          setTimeout(resolve, 200);
+        }),
+        semaphore: testSem,
+        sqs
+      });
+
+      consumer.start();
+
+      for (let i = 0; i < 40; i += 1) {
+        await clock.tickAsync(15);
+      }
+
+      consumer.stop();
+
+      assert.strictEqual(testSem.count, semaphoreCapacity, 'Expected semaphore count to be equal capacity');
+      assert.strictEqual(testSem.acquireCount, expectedAcquireCount, 'Expected acquire to be called ' + expectedAcquireCount + ' times');
+      assert.strictEqual(testSem.releaseCount, expectedReleaseCount, 'Expected release to be called ' + expectedReleaseCount + ' times');
+      assert.strictEqual(handleMessageCount, expectedHandleMessageCount, 'Expected handle message to be called ' + expectedHandleMessageCount + ' times');
+      assert.strictEqual(testSem.notReadyCount, expectesNotReadCount, 'Expected semaphore to be not read' + expectesNotReadCount + ' times');
     });
 
     it('extends visibility timeout for long running handler functions', async () => {


### PR DESCRIPTION
## Description
Accept a semaphore [async-mutex like](https://github.com/DirtyHairy/async-mutex/). The semaphore class is a interface, so we can use other lib instead.

## Motivation and Context
Call poll function several times without waiting handling execute.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
- [x] All new and existing tests passed.
